### PR TITLE
V2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ hti = Html2Image()
 <summary> Multiple arguments can be passed to the constructor (click to expand):</summary>
 
 -   `browser` :  Browser that will be used, set by default to `'chrome'` (the only browser supported by HTML2Image at the moment)
--   `browser_path` : The path or the command that can be used to find the executable of a specific browser.
+-   `browser_executable` : The path or the command that can be used to find the executable of a specific browser.
 -   `output_path` : Path to the folder to which taken screenshots will be outputed. Default is the current working directory of your python program.
 -   `size` : 2-Tuple reprensenting the size of the screenshots that will be taken. Default value is `(1920, 1080)`.
 -   `temp_path` : Path that will be used to put together different resources when screenshotting strings of files. Default value is `%TEMP%/html2image` on Windows, and `/tmp/html2image` on Linux and MacOS.

--- a/html2image/browsers/browser.py
+++ b/html2image/browsers/browser.py
@@ -9,12 +9,12 @@ class Browser(ABC):
 
     @property
     @abstractmethod
-    def executable_path(self):
+    def executable(self):
         pass
 
-    @executable_path.setter
+    @executable.setter
     @abstractmethod
-    def executable_path(self, value):
+    def executable(self, value):
         pass
 
     @abstractmethod

--- a/html2image/browsers/firefox.py
+++ b/html2image/browsers/firefox.py
@@ -10,11 +10,11 @@ class FirefoxHeadless(Browser):
         )
 
     @property
-    def executable_path(self):
+    def executable(self):
         pass
 
-    @executable_path.setter
-    def executable_path(self, value):
+    @executable.setter
+    def executable(self, value):
         pass
 
     def render(self, **kwargs):

--- a/html2image/browsers/search_utils.py
+++ b/html2image/browsers/search_utils.py
@@ -1,0 +1,98 @@
+import shutil
+import os
+from winreg import ConnectRegistry, OpenKey, QueryValueEx,\
+        HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER, KEY_READ
+
+
+def get_command_origin(command):
+    ''' Finds the path of a given command (windows only).
+
+    This function is inspired by the `start` command on windows.
+    It will search if the given command corresponds :
+    - To an executable in the current directory
+    - To an executable in the PATH environment variable
+    - To an executable mentionned in the registry in the
+      HKEY_LOCAL_MACHINE or HKEY_LOCAL_MACHINE hkeys in
+      SOFTWARE\\[Wow6432Node\\]Microsoft\\Windows\\CurrentVersion\\App Paths\\
+
+    It also "indirectly" validates a path to a file.
+
+    Parameters
+    ----------
+    - `command`: str
+        + command that will be searched.
+
+    Returns
+    -------
+    - str or None
+        + the path corresponding to `command`
+        + None, if no path was found
+    '''
+
+    # `start "command"` itself could be used to run the command but we want to
+    # assess that the command is a valid one.
+    command = command.replace('start ', '')
+
+    # which search in current directory + path
+    # and file extention can be ommited
+    which_result = shutil.which(command)
+    if which_result:
+        return which_result
+
+    # search for command in registry
+
+    command = command.replace('.exe', '').strip()
+
+    # Once combined, these hkeys and keys are where the `start`
+    # command seach for executable.
+    hkeys = [HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER]
+    keys = [
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\"
+        f"App Paths\\{command}.exe",
+
+        "SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\"
+        "CurrentVersion\\App Paths\\"
+        f"{command}.exe",
+    ]
+
+    for hkey in hkeys:
+        with ConnectRegistry(None, hkey) as registry:
+            for key in keys:
+                try:
+                    with OpenKey(registry, key, 0, KEY_READ) as k:
+                        # if no exception: we found the exe
+                        return QueryValueEx(k, '')[0]
+                except Exception:
+                    # cannot open key, do nothing and proceed to the next one
+                    pass
+    return None
+
+
+def find_first_defined_env_var(env_var_list, toggle):
+    '''
+    Returns the value of the first defined environment variable
+    encountered in the `env_var_list` list, but only if the
+    the `toggle` environment variableif defined.
+
+    Parameters
+    ----------
+    - `env_var_list`: list[str]
+        + list of environment variable names
+    - `toggle`: str
+        + environment variable name
+
+
+    '''
+    if toggle in os.environ:
+        for env_var in env_var_list:
+            value = os.environ.get(env_var)
+            if value:
+                return value
+    return None
+
+
+if __name__ == '__main__':
+    cmd_path = "C:\\Windows\\system32\\cmd.EXE"
+    print(f'{get_command_origin(cmd_path)=}')
+    print(f'{get_command_origin("chrome")=}')
+    print(f'{get_command_origin("chrome.exe")=}')

--- a/html2image/browsers/search_utils.py
+++ b/html2image/browsers/search_utils.py
@@ -1,7 +1,11 @@
 import shutil
 import os
-from winreg import ConnectRegistry, OpenKey, QueryValueEx,\
-        HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER, KEY_READ
+try:
+    from winreg import ConnectRegistry, OpenKey, QueryValueEx,\
+            HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER, KEY_READ
+except ImportError:
+    # os is not Windows, and there is no need for winreg
+    pass
 
 
 def get_command_origin(command):

--- a/html2image/browsers/search_utils.py
+++ b/html2image/browsers/search_utils.py
@@ -93,10 +93,3 @@ def find_first_defined_env_var(env_var_list, toggle):
             if value:
                 return value
     return None
-
-
-if __name__ == '__main__':
-    cmd_path = "C:\\Windows\\system32\\cmd.EXE"
-    print(f'{get_command_origin(cmd_path)=}')
-    print(f'{get_command_origin("chrome")=}')
-    print(f'{get_command_origin("chrome.exe")=}')

--- a/html2image/html2image.py
+++ b/html2image/html2image.py
@@ -37,7 +37,7 @@ class Html2Image():
             + Type of the browser that will be used to take screenshots.
             + Default is Chrome.
 
-        - `browser_path` : str, optional
+        - `browser_executable` : str, optional
             + Path to a browser executable.
 
         - `output_path` : str, optional
@@ -64,11 +64,11 @@ class Html2Image():
     def __init__(
         self,
         browser='chrome',
-        browser_path=None,
+        browser_executable=None,
         output_path=os.getcwd(),
         size=(1920, 1080),
         temp_path=None,
-        custom_flags=[],
+        custom_flags=None,
     ):
 
         if browser.lower() not in browser_map:
@@ -82,7 +82,7 @@ class Html2Image():
 
         browser_class = browser_map[browser.lower()]
         self.browser = browser_class(
-            executable_path=browser_path,
+            executable=browser_executable,
             flags=custom_flags,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "html2image"
-version = "2.0.0"
+version = "2.0.1"
 description = "Package acting as a wrapper around the headless mode of existing web browsers to generate images from URLs and from HTML+CSS strings or files."
 authors = ["vgalin"]
 license = "MIT"


### PR DESCRIPTION
- Fix #32 
On Linux when no Chrome/Chromium executable is given, the commands chrome, chromium, google-chrome and chromium-browser are checked.
- Better support for commands and "custom" executables on Windows.