### PR TITLE
Replace outdated URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ However, for the sake of taking screenshots, headless mode is not very convenien
 
 For more information about headless modes :
 -   (Chrome) [https://developers.google.com/web/updates/2017/04/headless-chrome](https://developers.google.com/web/updates/2017/04/headless-chrome)
--   (Firefox) [https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode)
+-   (Firefox) [https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode](https://web.archive.org/web/20210604151145/https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode)
 
 ## Installation
 HTML2Image is published on PyPI and can be installed through pip:


### PR DESCRIPTION
Hello. I noticed that the page https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode doesn't exist any more since, at least, July 30, 2021. I replaced the URL with the found newest URL from archive.org, on June 4, 2021.