### PR TITLE
changes needed for Debian on GH Codespaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM python
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 WORKDIR /pkgs/html2image
 COPY . .
 
-RUN $HOME/.poetry/bin/poetry install
-RUN $HOME/.poetry/bin/poetry build
+RUN $HOME/.local/bin/poetry install
+RUN $HOME/.local/bin/poetry build
 RUN pip install dist/*.whl
 
 RUN apt-get update -y && apt-get install -y chromium


### PR DESCRIPTION
When attempting to build this docker image on Debian inside Github Codespaces I got an error about Poetry v1.2 being deprecated and to switch to this new recommended install method. After these changes it would build successfully.

I'm confident the Poetry install change will work most everywhere. I'm less sure about the change for the `RUN $HOME` paths.