### PR TITLE
Fixing temporary folder management and snap validation in Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Poetry
+poetry.lock
+
 # Added
 .vscode/
 tests_output/

--- a/html2image/browsers/chrome.py
+++ b/html2image/browsers/chrome.py
@@ -251,8 +251,6 @@ class ChromeHeadless(Browser):
             f'{input}',
         ]
 
-        print(command)
-
         if self.print_command:
             print(' '.join(command))
 

--- a/html2image/browsers/chrome.py
+++ b/html2image/browsers/chrome.py
@@ -111,18 +111,6 @@ def _find_chrome(user_given_executable=None):
     # Search for executable on a Linux OS
     elif platform.system() == "Linux":
 
-        chrome_commands = [
-            'chromium',
-            'chromium-browser',
-            'chrome',
-            'google-chrome'
-        ]
-
-        for chrome_command in chrome_commands:
-            if shutil.which(chrome_command):
-                # check the --version for "chrom" ?
-                return chrome_command
-
         # snap seems to be a special case?
         # see https://stackoverflow.com/q/63375327/12182226
 
@@ -136,8 +124,21 @@ def _find_chrome(user_given_executable=None):
                 )
                 if os.path.isfile(chrome_snap):
                     return chrome_snap
+                
         except Exception:
             pass
+
+        chrome_commands = [
+            'chromium',
+            'chromium-browser',
+            'chrome',
+            'google-chrome'
+        ]
+
+        for chrome_command in chrome_commands:
+            if shutil.which(chrome_command):
+                # check the --version for "chrom" ?
+                return chrome_command
 
     # Search for executable on MacOS
     elif platform.system() == "Darwin":
@@ -249,6 +250,8 @@ class ChromeHeadless(Browser):
             *self.flags,
             f'{input}',
         ]
+
+        print(command)
 
         if self.print_command:
             print(' '.join(command))

--- a/html2image/html2image.py
+++ b/html2image/html2image.py
@@ -12,6 +12,7 @@ import os
 import shutil
 
 from textwrap import dedent
+from tempfile import TemporaryDirectory
 
 from html2image.browsers import chrome, firefox
 
@@ -92,16 +93,9 @@ class Html2Image():
 
     @temp_path.setter
     def temp_path(self, value):
-        if value is None:
-            temp_dir = os.environ['TMP'] if os.name == 'nt' else '/tmp'
-            temp_dir = os.path.join(temp_dir, 'html2image')
-        else:
-            temp_dir = value
-
-        # create the directory if it does not exist
-        os.makedirs(temp_dir, exist_ok=True)
-
-        self._temp_path = temp_dir
+        if value is not None:
+            os.makedirs(value, exist_ok=True)
+        self._temp_path = TemporaryDirectory(dir=value)
 
     @property
     def output_path(self):
@@ -135,7 +129,7 @@ class Html2Image():
             + Filename as which the given string will be saved.
 
         """
-        with open(os.path.join(self.temp_path, as_filename), 'wb') as f:
+        with open(os.path.join(self.temp_path.name, as_filename), 'wb') as f:
             f.write(content.encode('utf-8'))
 
     def load_file(self, src, as_filename=None):
@@ -158,7 +152,7 @@ class Html2Image():
         if as_filename is None:
             as_filename = os.path.basename(src)
 
-        dest = os.path.join(self.temp_path, as_filename)
+        dest = os.path.join(self.temp_path.name, as_filename)
         shutil.copyfile(src, dest)
 
     def screenshot_loaded_file(
@@ -181,7 +175,7 @@ class Html2Image():
             method is called.
         """
 
-        file = os.path.join(self.temp_path, file)
+        file = os.path.join(self.temp_path.name, file)
 
         if os.path.dirname(output_file) != '':
             raise ValueError(
@@ -513,6 +507,7 @@ class Html2Image():
             )
             screenshot_paths.append(os.path.join(self.output_path, name))
 
+        self.temp_path.cleanup()
         return screenshot_paths
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ include = [
 python = "^3.6"
 
 [tool.poetry.dev-dependencies]
+pytest = "7.0"
+Pillow = "8.4"
+pytest-parallel = "^0.1.1"
 
 [build-system]
 requires = ["poetry>=0.12"]
@@ -36,3 +39,9 @@ build-backend = "poetry.masonry.api"
 [tool.poetry.scripts]
 hti = 'html2image:main'
 html2image = 'html2image:main'
+
+[tool.pytest.ini_options]
+addopts = "--workers auto --tests-per-worker auto"
+testpaths = [
+    "tests"
+]


### PR DESCRIPTION
I made two things here:

- I replaced manually temporary folder management, to python stdlib `tempfile.TemporaryFolder`.
- I putted verification if chrome installation is `snap` before of native check.

I did this two comments, recently:

- https://github.com/vgalin/html2image/issues/117#issuecomment-1622693575
- https://github.com/vgalin/html2image/issues/46#issuecomment-1622698962

### About the permissions

When I used the library at first time, I got a blank image. But after override the `temp_path` parameter of `Html2Image`, it worked perfectly to me.

Then, at a first momment, trying to fix it, I replaced manual creation of the temporary folders, with ready-to-use, Python's `tempfile.TemporaryFolder` interface. But this didn't have fixed the problem. The blank image was still there.

### About the snap validation

I am using Chrome from snap. After I found the code validating the snap installation, and came to do some tests, using the absolute path declared in the code, the generation of the image got worked fine.

### Conclusion

Now, using the combination of the `tempfile` module and validating the `snap` installation first, the most of problems with blank images must be solved.