### PR TITLE
Fixed issue with periods in path

### DIFF
--- a/html2image/html2image.py
+++ b/html2image/html2image.py
@@ -510,7 +510,7 @@ class Html2Image():
             name = save_as.pop(0)
             current_size = size.pop(0)
 
-            html_filename = name.split('.')[0] + '.html'
+            html_filename = ''.join(name.split('.')[:-1]) + '.html'
             content = Html2Image._prepare_html_string(
                 html, css_style_string
             )

--- a/html2image/html2image.py
+++ b/html2image/html2image.py
@@ -510,7 +510,8 @@ class Html2Image():
             name = save_as.pop(0)
             current_size = size.pop(0)
 
-            html_filename = ''.join(name.split('.')[:-1]) + '.html'
+            base_name, _ = os.path.splitext(name)
+            html_filename = base_name + '.html'
             content = Html2Image._prepare_html_string(
                 html, css_style_string
             )


### PR DESCRIPTION
Fixes [issue 129](https://github.com/vgalin/html2image/issues/129). Currently, paths in the `save_as` list don't accept periods before the final period before the extension even though this is valid; e.g., `C:\Users\my.name.period\project\file.png`. 