### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = ">=3.6"
 websocket-client = "1.*"
 requests = "*"
 


### PR DESCRIPTION
`^3.6` means `>=3.6, <4` which is not necessary. No evidence shows that python 4 will break the package