### PR TITLE
Fix CLI and use old headless by default in chromium based browsers

### DIFF
--- a/html2image/browsers/chrome.py
+++ b/html2image/browsers/chrome.py
@@ -178,10 +178,12 @@ class ChromeHeadless(ChromiumHeadless):
             + Whether or not to print the command used to take a screenshot.
         - `disable_logging` : bool
             + Whether or not to disable Chrome's output.
+        - `should_use_new_headless_mode` : bool
+            + Whether or not to use the new headless mode.
     """
 
-    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False):
-        super().__init__(executable=executable, flags=flags, print_command=print_command, disable_logging=disable_logging)
+    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, should_use_new_headless_mode=False):
+        super().__init__(executable=executable, flags=flags, print_command=print_command, disable_logging=disable_logging, should_use_new_headless_mode=should_use_new_headless_mode)
 
     @property
     def executable(self):

--- a/html2image/browsers/chrome.py
+++ b/html2image/browsers/chrome.py
@@ -178,12 +178,14 @@ class ChromeHeadless(ChromiumHeadless):
             + Whether or not to print the command used to take a screenshot.
         - `disable_logging` : bool
             + Whether or not to disable Chrome's output.
-        - `should_use_new_headless_mode` : bool
+        - `use_new_headless` : bool, optional
             + Whether or not to use the new headless mode.
+            + By default, the old headless mode is used.
+            + You can also keep the original behavior to backward compatibility by setting this to `None`.
     """
 
-    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, should_use_new_headless_mode=False):
-        super().__init__(executable=executable, flags=flags, print_command=print_command, disable_logging=disable_logging, should_use_new_headless_mode=should_use_new_headless_mode)
+    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, use_new_headless=False,):
+        super().__init__(executable=executable, flags=flags, print_command=print_command, disable_logging=disable_logging, use_new_headless=use_new_headless)
 
     @property
     def executable(self):

--- a/html2image/browsers/chromium.py
+++ b/html2image/browsers/chromium.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 class ChromiumHeadless(Browser):
-    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False):
+    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, should_use_new_headless_mode=False):
         self.executable = executable
         if not flags:
             self.flags = [
@@ -16,6 +16,7 @@ class ChromiumHeadless(Browser):
 
         self.print_command = print_command
         self.disable_logging = disable_logging
+        self.should_use_new_headless_mode = should_use_new_headless_mode
 
     def screenshot(
         self,
@@ -58,9 +59,11 @@ class ChromiumHeadless(Browser):
 
         # command used to launch chrome in
         # headless mode and take a screenshot
+        headless_mode = 'new' if self.should_use_new_headless_mode else 'old'
+
         command = [
             f'{self.executable}',
-            '--headless',
+            f'--headless={headless_mode}',
             f'--screenshot={os.path.join(output_path, output_file)}',
             f'--window-size={size[0]},{size[1]}',
             *self.flags,

--- a/html2image/browsers/chromium.py
+++ b/html2image/browsers/chromium.py
@@ -4,7 +4,29 @@ import os
 import subprocess
 
 class ChromiumHeadless(Browser):
-    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, should_use_new_headless_mode=False):
+    """
+        Chrome/Chromium browser wrapper.
+
+        Parameters
+        ----------
+        - `executable` : str, optional
+            + Path to a chrome executable.
+        - `flags` : list of str
+            + Flags to be used by the headless browser.
+            + Default flags are :
+                - '--default-background-color=00000000'
+                - '--hide-scrollbars'
+        - `print_command` : bool
+            + Whether or not to print the command used to take a screenshot.
+        - `disable_logging` : bool
+            + Whether or not to disable Chrome's output.
+        - `use_new_headless` : bool, optional
+            + Whether or not to use the new headless mode.
+            + By default, the old headless mode is used.
+            + You can also keep the original behavior to backward compatibility by setting this to `None`.
+    """
+
+    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, use_new_headless=False,):
         self.executable = executable
         if not flags:
             self.flags = [
@@ -16,7 +38,7 @@ class ChromiumHeadless(Browser):
 
         self.print_command = print_command
         self.disable_logging = disable_logging
-        self.should_use_new_headless_mode = should_use_new_headless_mode
+        self.use_new_headless = use_new_headless
 
     def screenshot(
         self,
@@ -59,11 +81,13 @@ class ChromiumHeadless(Browser):
 
         # command used to launch chrome in
         # headless mode and take a screenshot
-        headless_mode = 'new' if self.should_use_new_headless_mode else 'old'
+        headless_mode = '--headless'
+        if self.use_new_headless is not None:
+            headless_mode += '=new' if self.use_new_headless else '=old'
 
         command = [
             f'{self.executable}',
-            f'--headless={headless_mode}',
+            f'{headless_mode}',
             f'--screenshot={os.path.join(output_path, output_file)}',
             f'--window-size={size[0]},{size[1]}',
             *self.flags,

--- a/html2image/browsers/edge.py
+++ b/html2image/browsers/edge.py
@@ -160,8 +160,8 @@ class EdgeHeadless(ChromiumHeadless):
             + Whether or not to print the command used to take a screenshot.
     """
 
-    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False):
-        super().__init__(executable=executable, flags=flags, print_command=print_command, disable_logging=disable_logging)
+    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, should_use_new_headless_mode=False):
+        super().__init__(executable=executable, flags=flags, print_command=print_command, disable_logging=disable_logging, should_use_new_headless_mode=should_use_new_headless_mode)
 
     @property
     def executable(self):

--- a/html2image/browsers/edge.py
+++ b/html2image/browsers/edge.py
@@ -150,7 +150,6 @@ class EdgeHeadless(ChromiumHeadless):
         ----------
         - `executable` : str, optional
             + Path to a edge executable.
-
         - `flags` : list of str
             + Flags to be used by the headless browser.
             + Default flags are :
@@ -158,10 +157,16 @@ class EdgeHeadless(ChromiumHeadless):
                 - '--hide-scrollbars'
         - `print_command` : bool
             + Whether or not to print the command used to take a screenshot.
+        - `disable_logging` : bool
+            + Whether or not to disable Chrome's output.
+        - `use_new_headless` : bool, optional
+            + Whether or not to use the new headless mode.
+            + By default, the old headless mode is used.
+            + You can also keep the original behavior to backward compatibility by setting this to `None`.
     """
 
-    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, should_use_new_headless_mode=False):
-        super().__init__(executable=executable, flags=flags, print_command=print_command, disable_logging=disable_logging, should_use_new_headless_mode=should_use_new_headless_mode)
+    def __init__(self, executable=None, flags=None, print_command=False, disable_logging=False, use_new_headless=False,):
+        super().__init__(executable=executable, flags=flags, print_command=print_command, disable_logging=disable_logging, use_new_headless=use_new_headless)
 
     @property
     def executable(self):

--- a/html2image/cli.py
+++ b/html2image/cli.py
@@ -65,8 +65,7 @@ def main():
 
     paths = hti.screenshot(
         html_file=args.html, css_file=args.css, other_file=args.other,
-        url=args.url, save_as=args.save_as, size=args.size,
-        browser_executable=args.chrome_path,
+        url=args.url, save_as=args.save_as, size=args.size
     )
 
     if not args.quiet:


### PR DESCRIPTION
fix #156
fix #155

Reference links
- https://developer.chrome.com/docs/chromium/new-headless
- https://developer.chrome.com/blog/chrome-headless-shell


> Note: Passing the --headless command-line flag without an explicit value still activates the old Headless mode, but we intend to change this default. We intend to remove the old Headless from the Chrome binary and stop supporting this mode in Puppeteer in 2024. Simultaneously, we'll make old Headless mode available as a standalone binary for users who can't upgrade yet.

The moment mentioned in the quote above has arrived.