### PR TITLE
Default headless flag added for ChromiumHeadless and ChromeCDP 

### DIFF
--- a/html2image/browsers/chrome_cdp.py
+++ b/html2image/browsers/chrome_cdp.py
@@ -26,6 +26,7 @@ class ChromeCDP(CDPBrowser):
             # the browser from running
             self.flags = [
                 '--hide-scrollbars',
+                '--headless',
             ]
         else:
             self.flags = [flags] if isinstance(flags, str) else flags

--- a/html2image/browsers/chromium.py
+++ b/html2image/browsers/chromium.py
@@ -32,6 +32,7 @@ class ChromiumHeadless(Browser):
             self.flags = [
                 '--default-background-color=00000000',
                 '--hide-scrollbars',
+                '--headless',
             ]
         else:
             self.flags = [flags] if isinstance(flags, str) else flags


### PR DESCRIPTION
This change address issue for chrome headless:

`Old Headless mode has been removed from the Chrome binary. Please use the new Headless mode (https://developer.chrome.com/docs/chromium/new-headless) or the chrome-headless-shell which is a standalone implementation of the old Headless mode (https://developer.chrome.com/blog/chrome-headless-shell).`