### PR TITLE
Fix CDP browser detection

### DIFF
--- a/html2image/html2image.py
+++ b/html2image/html2image.py
@@ -96,7 +96,10 @@ class Html2Image():
 
         browser_class = browser_map[browser.lower()]
 
-        if isinstance(browser_class, CDPBrowser):
+        # browser_map stores classes, not instances. Use ``issubclass`` to
+        # check if the selected browser class supports the Chrome DevTools
+        # Protocol and therefore expects the ``cdp_port`` argument.
+        if issubclass(browser_class, CDPBrowser):
             self.browser = browser_class(
                 executable=browser_executable,
                 flags=custom_flags,


### PR DESCRIPTION
## Summary
- detect CDP-enabled browsers with `issubclass`

## Testing
- `pytest -q` *(fails: Could not find a Chrome/Edge executable)*

------
https://chatgpt.com/codex/tasks/task_e_683f5efb33cc83208c61a2b98f8b469e